### PR TITLE
Correção de spiders do hemato

### DIFF
--- a/doe_sangue/spiders/constants.py
+++ b/doe_sangue/spiders/constants.py
@@ -30,3 +30,39 @@ XPATH_ADDRESS = {
 XPATH_CITY = {
     'hemato': '//div[contains(@class, "container-segura")]/section/div/div[1]/p[3]/text()'
 }
+XPATH_ITEMS = {
+    'hemato': '//div[contains(@class,"item-estoque")]',
+    'hemope': '//ul[contains(@class,"list-estoque")]/li'
+}
+
+XPATH_TIPO_SANGUE = {
+    'hemato': './/div[contains(@class, tipo-sangue)][2]/text()',
+    'hemope': './/strong/text()'
+}
+
+XPATH_NIVEL_SANGUE = {
+    'hemato': './/div[contains(@class, "knob")]/@data-val[1]',
+    'hemope': './/div[contains(@class,"bolsa")]/div[2]/@class'
+}
+
+XPATH_PAGES = {
+    'hemato': './/li[contains(@class, "dropdown")][1]/ul[contains(@class, "dropdown-menu")]/li/a'
+}
+
+XPATH_PLACE_NAME = {
+    'hemato': '//div[contains(@class, "container-segura")]/section/div/div[1]/p[3]/text()',
+    'hemope': '//a/img/@alt'
+}
+
+XPATH_ADDRESS = {
+    'hemato': '//div[contains(@class, "container-segura")]/section/div/div[1]/p[1]/text()',
+    'hemope': '//address/strong[1]/text()'
+}
+
+XPATH_CITY = {
+    'hemato': '//div[contains(@class, "container-segura")]/section/div/div[1]/p[3]/text()'
+}
+
+XPATH_CITY_WITHOUT_COMPLEMENT = {
+    'hemato': '//div[contains(@class, "container-segura")]/section/div/div[1]/p[2]/text()'
+}

--- a/doe_sangue/spiders/hemato.py
+++ b/doe_sangue/spiders/hemato.py
@@ -7,7 +7,8 @@ from .constants import (
     XPATH_NIVEL_SANGUE,
     XPATH_PAGES,
     XPATH_ADDRESS,
-    XPATH_CITY
+    XPATH_CITY,
+    XPATH_CITY_WITHOUT_COMPLEMENT
 )
 
 
@@ -32,10 +33,16 @@ class HematoSpider(scrapy.Spider):
         item['data_extracao'] = datetime.now()
 
         item['endereco'] = response.xpath(
-                XPATH_ADDRESS['hemato']).extract_first()
+            XPATH_ADDRESS['hemato']).extract_first()
 
-        item['cidade'] = response.xpath(
-                XPATH_CITY['hemato']).extract_first()
+        cidade = response.xpath(
+            XPATH_CITY['hemato']).extract_first()
+
+        if len(cidade.strip()) > 0:
+            item['cidade'] = cidade
+        else:
+            item['cidade'] = response.xpath(
+                XPATH_CITY_WITHOUT_COMPLEMENT['hemato']).extract_first()
 
         item['_id'] = item['banco'] + "-" + item['cidade']
 


### PR DESCRIPTION
Esse pull request corrige a issue #2 adicionando um seletor XPATH_CITY_WITHOUT_COMPLEMENT para os casos onde o seletor original retorna um texto vazio.

Esses casos ocorrem quando o endereço não possui uma linha de complemento, nesses casos a única mudança necessária é usar o segundo parágrafo ao invés do terceiro

Fixes #2 